### PR TITLE
fix: import process instead of globally accessing

### DIFF
--- a/src/tests/test-manager.ts
+++ b/src/tests/test-manager.ts
@@ -1,3 +1,4 @@
+import process from "process";
 import { RenovationBackend } from "../config";
 import { Renovation } from "../renovation";
 


### PR DESCRIPTION
The issue was importing process instead of accessing it globally. I have tested it on an Angular project and the error is gone. Please confirm the same.