### PR TITLE
JWT disabled by default + Check App installation in backend

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -31,12 +31,12 @@ export default abstract class AuthController extends RenovationController {
   /**
    * Set this to true to disable JWT
    */
-  public set disableJwt(value) {
+  public set enableJwt(value) {
     this.useJwt = value;
   }
 
-  public get disableJwt() {
-    return !this.useJwt;
+  public get enableJwt() {
+    return this.useJwt;
   }
 
   /**
@@ -51,7 +51,7 @@ export default abstract class AuthController extends RenovationController {
   /**
    * Enable jwt if this is true only
    */
-  protected useJwt: boolean = true;
+  protected useJwt: boolean = false;
   /**
    * The current user's roles
    *

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -313,7 +313,8 @@ export default abstract class AuthController extends RenovationController {
         if (newStatus.lang) {
           this.getCore().translate.setCurrentLanguage({ lang: newStatus.lang });
         }
-        this.getCore().translate.loadTranslations({});
+        if (this.getCore().frappe.getAppVersion("renovation_core"))
+          this.getCore().translate.loadTranslations({});
         this.currentUser = newStatus.user;
       } else {
         this.clearAuthToken();

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -32,6 +32,9 @@ export default abstract class AuthController extends RenovationController {
    * Set this to true to disable JWT
    */
   public set enableJwt(value) {
+    if (!this.getCore().frappe.getAppVersion("renovation_core") && value) {
+      this.getCore().frappe.checkAppInstalled(["Login using JWT"]);
+    }
     this.useJwt = value;
   }
 

--- a/src/auth/frappe.auth.controller.ts
+++ b/src/auth/frappe.auth.controller.ts
@@ -254,6 +254,7 @@ export default class FrappeAuthController extends AuthController {
     user: string | PinLoginParams,
     pin?: string
   ): Promise<RequestResponse<SessionStatusInfo>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     if (typeof user === "string") {
       renovationWarn(
         "LTS-Renovation-Core",
@@ -287,6 +288,8 @@ export default class FrappeAuthController extends AuthController {
   public async sendOTP(
     sendOTPParams: SendOTPParams
   ): Promise<RequestResponse<SendOTPResponse>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
+
     const response = await Request(
       `${this.config.hostUrl}/api/method/renovation/auth.sms.generate`,
       httpMethod.POST,
@@ -317,6 +320,8 @@ export default class FrappeAuthController extends AuthController {
   public async verifyOTP(
     verifyOTPParams: VerifyOTPParams
   ): Promise<RequestResponse<VerifyOTPResponse>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
+
     const response = await Request(
       `${this.config.hostUrl}/api/method/renovation/auth.sms.verify`,
       httpMethod.POST,
@@ -365,6 +370,8 @@ export default class FrappeAuthController extends AuthController {
    * @returns {Promise<RequestResponse<string[]>>} The list of roles for the user. If a user is not signed-in, the Guest roles are fetched
    */
   public async getCurrentUserRoles(): Promise<RequestResponse<string[]>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
+
     if (
       this.currentUserRoles &&
       this.currentUserRoles.length &&

--- a/src/auth/frappe.auth.controller.ts
+++ b/src/auth/frappe.auth.controller.ts
@@ -254,7 +254,7 @@ export default class FrappeAuthController extends AuthController {
     user: string | PinLoginParams,
     pin?: string
   ): Promise<RequestResponse<SessionStatusInfo>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["pinLogin"]);
     if (typeof user === "string") {
       renovationWarn(
         "LTS-Renovation-Core",
@@ -288,7 +288,7 @@ export default class FrappeAuthController extends AuthController {
   public async sendOTP(
     sendOTPParams: SendOTPParams
   ): Promise<RequestResponse<SendOTPResponse>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["sendOTP"]);
 
     const response = await Request(
       `${this.config.hostUrl}/api/method/renovation/auth.sms.generate`,
@@ -320,7 +320,7 @@ export default class FrappeAuthController extends AuthController {
   public async verifyOTP(
     verifyOTPParams: VerifyOTPParams
   ): Promise<RequestResponse<VerifyOTPResponse>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["verifyOTP"]);
 
     const response = await Request(
       `${this.config.hostUrl}/api/method/renovation/auth.sms.verify`,
@@ -370,7 +370,7 @@ export default class FrappeAuthController extends AuthController {
    * @returns {Promise<RequestResponse<string[]>>} The list of roles for the user. If a user is not signed-in, the Guest roles are fetched
    */
   public async getCurrentUserRoles(): Promise<RequestResponse<string[]>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["getCurrentUserRoles"]);
 
     if (
       this.currentUserRoles &&

--- a/src/dashboard/frappe.dashboard.controller.ts
+++ b/src/dashboard/frappe.dashboard.controller.ts
@@ -59,7 +59,7 @@ export default class FrappeDashboardController extends DashboardController {
   public async getDashboardLayout(
     getDashboardLayoutParams?: GetDashboardLayoutParams
   ): Promise<RequestResponse<DashboardLayout>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["getDashboardLayout"]);
     const layout = getDashboardLayoutParams
       ? getDashboardLayoutParams.layout
       : undefined;
@@ -81,7 +81,7 @@ export default class FrappeDashboardController extends DashboardController {
   public async getAvailableLayouts(): Promise<
     RequestResponse<Array<{ title: string; name: string }>>
   > {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["getAvailableLayouts"]);
     const r = await this.getCore().call({
       cmd: "renovation_core.renovation_dashboard_def.get_user_dashboard_layouts"
     });
@@ -127,6 +127,8 @@ export default class FrappeDashboardController extends DashboardController {
   public async getAllDashboardsMeta(): Promise<
     RequestResponse<FrappeDashboard[]>
   > {
+    await this.getCore().frappe.checkAppInstalled(["getAllDashboardMeta"]);
+
     const cachedDashboards = this.getDashboardsFromCache();
     if (cachedDashboards) {
       this.fetchDashboards();
@@ -389,7 +391,7 @@ export default class FrappeDashboardController extends DashboardController {
     dashboard: FrappeDashboard,
     params?: FrappeDashboardParams[]
   ): Promise<RequestResponse<any>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["executeDefaultCMD"]);
     const dashboardParams = {};
 
     for (const param of params || []) {
@@ -493,7 +495,6 @@ export default class FrappeDashboardController extends DashboardController {
    * @returns {Promise<RequestResponse<FrappeDashboard[]>>} The `FrappeDashboard` array retrieved within `RequestResponse`
    */
   private async fetchDashboards(): Promise<RequestResponse<FrappeDashboard[]>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
     const dashboards = await this.getCore().call({
       cmd: "renovation_core.renovation_dashboard_def.get_all_dashboard_meta"
     });

--- a/src/dashboard/frappe.dashboard.controller.ts
+++ b/src/dashboard/frappe.dashboard.controller.ts
@@ -1,4 +1,10 @@
-import { deepCompare, renovationError, RenovationError, renovationLog, RequestResponse } from "..";
+import {
+  deepCompare,
+  renovationError,
+  RenovationError,
+  renovationLog,
+  RequestResponse
+} from "..";
 import { RenovationConfig } from "../config";
 import RenovationController from "../renovation.controller";
 import { ErrorDetail } from "../utils/error";
@@ -53,6 +59,7 @@ export default class FrappeDashboardController extends DashboardController {
   public async getDashboardLayout(
     getDashboardLayoutParams?: GetDashboardLayoutParams
   ): Promise<RequestResponse<DashboardLayout>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     const layout = getDashboardLayoutParams
       ? getDashboardLayoutParams.layout
       : undefined;
@@ -74,6 +81,7 @@ export default class FrappeDashboardController extends DashboardController {
   public async getAvailableLayouts(): Promise<
     RequestResponse<Array<{ title: string; name: string }>>
   > {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     const r = await this.getCore().call({
       cmd: "renovation_core.renovation_dashboard_def.get_user_dashboard_layouts"
     });
@@ -381,6 +389,7 @@ export default class FrappeDashboardController extends DashboardController {
     dashboard: FrappeDashboard,
     params?: FrappeDashboardParams[]
   ): Promise<RequestResponse<any>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     const dashboardParams = {};
 
     for (const param of params || []) {
@@ -484,6 +493,7 @@ export default class FrappeDashboardController extends DashboardController {
    * @returns {Promise<RequestResponse<FrappeDashboard[]>>} The `FrappeDashboard` array retrieved within `RequestResponse`
    */
   private async fetchDashboards(): Promise<RequestResponse<FrappeDashboard[]>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     const dashboards = await this.getCore().call({
       cmd: "renovation_core.renovation_dashboard_def.get_all_dashboard_meta"
     });

--- a/src/defaults/frappe.defaults.controller.ts
+++ b/src/defaults/frappe.defaults.controller.ts
@@ -57,7 +57,7 @@ export default class FrappeDefaultsController extends DefaultsController {
     getDefaultParams: string | GetDefaultParams,
     parent = "__default"
   ): Promise<RequestResponse<unknown>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["getDefault"]);
     if (typeof getDefaultParams === "string") {
       renovationWarn(
         "LTS-Renovation-Core",

--- a/src/defaults/frappe.defaults.controller.ts
+++ b/src/defaults/frappe.defaults.controller.ts
@@ -57,6 +57,7 @@ export default class FrappeDefaultsController extends DefaultsController {
     getDefaultParams: string | GetDefaultParams,
     parent = "__default"
   ): Promise<RequestResponse<unknown>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     if (typeof getDefaultParams === "string") {
       renovationWarn(
         "LTS-Renovation-Core",

--- a/src/lib/frappe.ts
+++ b/src/lib/frappe.ts
@@ -220,17 +220,26 @@ export default class Frappe extends RenovationController {
   }
 
   /**
-   * Silent method throwing an error if 'renovation_core' is not installed in the backend.
+   * Silent method throwing an error if an app is not installed in the backend
    *
-   * To be used in controller's methods where the endpoints are defined in 'renovation_core'.
+   * Defaults to checking 'renovation_core' and defaults to throw an error
+   *
+   * Awaits until the version is loaded through loadAppVersions
    */
-  public async checkRenovationCoreInstalled(): Promise<void> {
+  public async checkAppInstalled(
+    features: string[],
+    throwError: boolean = true,
+    appName: string = "renovation_core"
+  ): Promise<void> {
     while (!this._versionsLoaded) {
       await asyncSleep(100);
     }
-    if (!Object.keys(this._appVersions).includes("renovation_core")) {
-      throw new Error(
-        "The app renovation_core is not installed in the backend. Please install it and try again"
+    if (!Object.keys(this._appVersions).includes(appName) && throwError) {
+      throw Error(
+        `The app "${appName}" is not installed in the backend.\nPlease install it to be able to use the feature(s):\n\n${
+          features && features.length ? features.join("\n") : ""
+        }
+         `
       );
     }
   }

--- a/src/lib/frappe.ts
+++ b/src/lib/frappe.ts
@@ -213,4 +213,17 @@ export default class Frappe extends RenovationController {
     }
     throw Error("Version empty or not in proper format");
   }
+
+  /**
+   * Silent method throwing an error if 'renovation_core' is not installed in the backend.
+   *
+   * To be used in controller's methods where the endpoints are defined in 'renovation_core'.
+   */
+  public checkRenovationCoreInstalled(): void {
+    if (!Object.keys(this._appVersions).includes("renovation_core")) {
+      throw new Error(
+        "The app renovation_core is not installed in the backend. Please install it and try again"
+      );
+    }
+  }
 }

--- a/src/lib/frappe.ts
+++ b/src/lib/frappe.ts
@@ -17,6 +17,8 @@ import { AppVersion } from "./interfaces";
 export default class Frappe extends RenovationController {
   private _appVersions: { [x: string]: AppVersion } = {};
 
+  private _versionsLoaded: boolean = false;
+
   public get appVersions() {
     return this._appVersions;
   }
@@ -186,6 +188,7 @@ export default class Frappe extends RenovationController {
     const response = await this.config.coreInstance.call({
       cmd: "renovation_core.utils.site.get_versions"
     });
+    this._versionsLoaded = true;
     if (response.success) {
       const versions = response.data.message as { [x: string]: AppVersion };
       if (versions) {
@@ -222,7 +225,7 @@ export default class Frappe extends RenovationController {
    * To be used in controller's methods where the endpoints are defined in 'renovation_core'.
    */
   public async checkRenovationCoreInstalled(): Promise<void> {
-    while (Object.keys(this._appVersions).length === 0) {
+    while (!this._versionsLoaded) {
       await asyncSleep(100);
     }
     if (!Object.keys(this._appVersions).includes("renovation_core")) {

--- a/src/lib/log.manager.ts
+++ b/src/lib/log.manager.ts
@@ -150,6 +150,7 @@ export default class LogManager extends RenovationController {
    * @param {InvokeLoggerParams} params
    */
   private async invokeLogger(params: InvokeLoggerParams) {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     if (params.tags && typeof params.tags === "object") {
       params.tags.push(...this._defaultTags);
       // frappe param bug

--- a/src/lib/log.manager.ts
+++ b/src/lib/log.manager.ts
@@ -150,7 +150,7 @@ export default class LogManager extends RenovationController {
    * @param {InvokeLoggerParams} params
    */
   private async invokeLogger(params: InvokeLoggerParams) {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["Logger"]);
     if (params.tags && typeof params.tags === "object") {
       params.tags.push(...this._defaultTags);
       // frappe param bug

--- a/src/meta/frappe.meta.controller.ts
+++ b/src/meta/frappe.meta.controller.ts
@@ -221,7 +221,7 @@ export default class FrappeMetaController extends MetaController {
   public async getDocMeta(
     getDocMetaParams: string | GetDocMetaParams
   ): Promise<RequestResponse<DocType>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["getDocMeta"]);
     let doctype;
     if (typeof getDocMetaParams === "string") {
       doctype = getDocMetaParams;

--- a/src/meta/frappe.meta.controller.ts
+++ b/src/meta/frappe.meta.controller.ts
@@ -221,6 +221,7 @@ export default class FrappeMetaController extends MetaController {
   public async getDocMeta(
     getDocMetaParams: string | GetDocMetaParams
   ): Promise<RequestResponse<DocType>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     let doctype;
     if (typeof getDocMetaParams === "string") {
       doctype = getDocMetaParams;

--- a/src/model/frappe.model.controller.ts
+++ b/src/model/frappe.model.controller.ts
@@ -249,6 +249,7 @@ export default class FrappeModelController extends ModelController {
     getDocParams: GetDocParams | string,
     docname?: string
   ): Promise<RequestResponse<RenovationDocument>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     let args: GetDocParams;
     if (typeof getDocParams === "string") {
       args = {
@@ -381,6 +382,7 @@ export default class FrappeModelController extends ModelController {
     limitPageLength?: number,
     parent?: string
   ): Promise<RequestResponse<[{ [x: string]: DBBasicValues | [{}] }]>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     if (typeof getListParams === "string" || arguments.length > 1) {
       renovationWarn(
         "LTS-Renovation-Core",
@@ -626,6 +628,7 @@ export default class FrappeModelController extends ModelController {
     filters = {},
     user = null
   ): Promise<RequestResponse<{ result; columns }>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     let args: GetReportParams;
     if (typeof getReportParams === "string") {
       renovationWarn(
@@ -817,6 +820,7 @@ export default class FrappeModelController extends ModelController {
   public async saveDoc(
     saveDocParams: SaveDocParams | RenovationDocument
   ): Promise<RequestResponse<RenovationDocument>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     let doc: RenovationDocument;
     // @ts-ignore
     if (saveDocParams.doc && !saveDocParams.doctype) {
@@ -977,6 +981,7 @@ export default class FrappeModelController extends ModelController {
   public async saveSubmitDoc(
     saveSubmitDocParams: SaveSubmitDocParams | RenovationDocument
   ): Promise<RequestResponse<RenovationDocument>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     let doc: RenovationDocument;
     // @ts-ignore
     if (saveSubmitDocParams.doc && !saveSubmitDocParams.doctype) {
@@ -1234,6 +1239,7 @@ export default class FrappeModelController extends ModelController {
   public async unAssignDoc(
     unAssignDocParams: UnAssignDocParams
   ): Promise<RequestResponse<any>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     const r = await this.getCore().call({
       cmd: "renovation_core.utils.assign_doc.unAssignDocFromUser",
       doctype: unAssignDocParams.doctype,
@@ -1256,6 +1262,7 @@ export default class FrappeModelController extends ModelController {
   public async getDocsAssignedToUser(
     getDocsAssignedToUserParams: GetDocsAssignedToUserParams
   ): Promise<RequestResponse<GetDocsAssignedToUserResponse[]>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     if (!getDocsAssignedToUserParams.assignedTo) {
       // ToDo isnt supposed to be set for Guests
       getDocsAssignedToUserParams.assignedTo = this.getCore().auth.getCurrentUser();

--- a/src/model/frappe.model.controller.ts
+++ b/src/model/frappe.model.controller.ts
@@ -249,7 +249,7 @@ export default class FrappeModelController extends ModelController {
     getDocParams: GetDocParams | string,
     docname?: string
   ): Promise<RequestResponse<RenovationDocument>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["getDoc"]);
     let args: GetDocParams;
     if (typeof getDocParams === "string") {
       args = {
@@ -382,7 +382,7 @@ export default class FrappeModelController extends ModelController {
     limitPageLength?: number,
     parent?: string
   ): Promise<RequestResponse<[{ [x: string]: DBBasicValues | [{}] }]>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["getList"]);
     if (typeof getListParams === "string" || arguments.length > 1) {
       renovationWarn(
         "LTS-Renovation-Core",
@@ -628,7 +628,9 @@ export default class FrappeModelController extends ModelController {
     filters = {},
     user = null
   ): Promise<RequestResponse<{ result; columns }>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled([
+      "getReport (Renovation Report)"
+    ]);
     let args: GetReportParams;
     if (typeof getReportParams === "string") {
       renovationWarn(
@@ -820,7 +822,7 @@ export default class FrappeModelController extends ModelController {
   public async saveDoc(
     saveDocParams: SaveDocParams | RenovationDocument
   ): Promise<RequestResponse<RenovationDocument>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["saveDoc"]);
     let doc: RenovationDocument;
     // @ts-ignore
     if (saveDocParams.doc && !saveDocParams.doctype) {
@@ -981,7 +983,7 @@ export default class FrappeModelController extends ModelController {
   public async saveSubmitDoc(
     saveSubmitDocParams: SaveSubmitDocParams | RenovationDocument
   ): Promise<RequestResponse<RenovationDocument>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["saveSubmitDoc"]);
     let doc: RenovationDocument;
     // @ts-ignore
     if (saveSubmitDocParams.doc && !saveSubmitDocParams.doctype) {
@@ -1239,7 +1241,7 @@ export default class FrappeModelController extends ModelController {
   public async unAssignDoc(
     unAssignDocParams: UnAssignDocParams
   ): Promise<RequestResponse<any>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["unAssignDoc"]);
     const r = await this.getCore().call({
       cmd: "renovation_core.utils.assign_doc.unAssignDocFromUser",
       doctype: unAssignDocParams.doctype,
@@ -1262,7 +1264,7 @@ export default class FrappeModelController extends ModelController {
   public async getDocsAssignedToUser(
     getDocsAssignedToUserParams: GetDocsAssignedToUserParams
   ): Promise<RequestResponse<GetDocsAssignedToUserResponse[]>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["GetDocsAssignedToUser"]);
     if (!getDocsAssignedToUserParams.assignedTo) {
       // ToDo isnt supposed to be set for Guests
       getDocsAssignedToUserParams.assignedTo = this.getCore().auth.getCurrentUser();

--- a/src/perm/frappe.perm.controller.ts
+++ b/src/perm/frappe.perm.controller.ts
@@ -32,6 +32,7 @@ export default class FrappePermissionController extends PermissionController {
    * If a user isn't signed in, the Guest basic permissions is retrieved
    */
   public async loadBasicPerms() {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     if (this.basicPerms) {
       if (this.basicPerms.isLoading) {
         await asyncSleep(50);

--- a/src/perm/frappe.perm.controller.ts
+++ b/src/perm/frappe.perm.controller.ts
@@ -32,7 +32,7 @@ export default class FrappePermissionController extends PermissionController {
    * If a user isn't signed in, the Guest basic permissions is retrieved
    */
   public async loadBasicPerms() {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["loadBasicPerms"]);
     if (this.basicPerms) {
       if (this.basicPerms.isLoading) {
         await asyncSleep(50);

--- a/src/renovation.ts
+++ b/src/renovation.ts
@@ -194,6 +194,10 @@ export class Renovation {
     this.initCall();
 
     if (initParams.backend === "frappe") {
+
+      this.frappe = new Frappe(this.config);
+      await this.frappe.loadAppVersions();
+      
       this.defaults = new FrappeDefaultsController(this.config);
       this.model = new FrappeModelController(this.config);
       this.meta = new FrappeMetaController(this.config);
@@ -202,10 +206,6 @@ export class Renovation {
       this.ui = new FrappeUIController(this.config);
       this.translate = new FrappeTranslationController(this.config);
 
-      this.frappe = new Frappe(this.config);
-
-      // Load the apps' versions without awaiting
-      this.frappe.loadAppVersions();
 
       this.dashboard = new FrappeDashboardController(this.config);
       // define auth at last

--- a/src/renovation.ts
+++ b/src/renovation.ts
@@ -194,10 +194,11 @@ export class Renovation {
     this.initCall();
 
     if (initParams.backend === "frappe") {
-
       this.frappe = new Frappe(this.config);
-      await this.frappe.loadAppVersions();
-      
+
+      // Load the apps' versions without awaiting
+      this.frappe.loadAppVersions();
+
       this.defaults = new FrappeDefaultsController(this.config);
       this.model = new FrappeModelController(this.config);
       this.meta = new FrappeMetaController(this.config);
@@ -205,7 +206,6 @@ export class Renovation {
       this.storage = new FrappeStorageController(this.config);
       this.ui = new FrappeUIController(this.config);
       this.translate = new FrappeTranslationController(this.config);
-
 
       this.dashboard = new FrappeDashboardController(this.config);
       // define auth at last

--- a/src/storage/frappe.storage.controller.ts
+++ b/src/storage/frappe.storage.controller.ts
@@ -308,7 +308,7 @@ export default class FrappeStorageController extends StorageController {
   private async uploadViaHTTP(
     uploadFileParams: UploadFileParams
   ): Promise<RequestResponse<UploadFileResponse>> {
-    await this.getCore().frappe.checkAppInstalled(["uploadViaHTTP"]);
+    await this.getCore().frappe.checkAppInstalled(["uploadViaHTTP"], false);
     let readFilePromise = null;
     if (uploadFileParams.file) {
       readFilePromise = getBase64FromFileObject(uploadFileParams.file);
@@ -324,7 +324,9 @@ export default class FrappeStorageController extends StorageController {
     const r = await readFilePromise;
 
     const d = {
-      cmd: "renovation_core.handler.uploadfile",
+      cmd: this.getCore().frappe.getAppVersion("renovation_core")
+        ? "renovation_core.handler.uploadfile"
+        : "frappe.handler.uploadfile",
       from_form: 1,
       file_url: null,
       is_private: uploadFileParams.isPrivate ? 1 : 0,

--- a/src/storage/frappe.storage.controller.ts
+++ b/src/storage/frappe.storage.controller.ts
@@ -308,6 +308,7 @@ export default class FrappeStorageController extends StorageController {
   private async uploadViaHTTP(
     uploadFileParams: UploadFileParams
   ): Promise<RequestResponse<UploadFileResponse>> {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     let readFilePromise = null;
     if (uploadFileParams.file) {
       readFilePromise = getBase64FromFileObject(uploadFileParams.file);

--- a/src/storage/frappe.storage.controller.ts
+++ b/src/storage/frappe.storage.controller.ts
@@ -308,7 +308,7 @@ export default class FrappeStorageController extends StorageController {
   private async uploadViaHTTP(
     uploadFileParams: UploadFileParams
   ): Promise<RequestResponse<UploadFileResponse>> {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["uploadViaHTTP"]);
     let readFilePromise = null;
     if (uploadFileParams.file) {
       readFilePromise = getBase64FromFileObject(uploadFileParams.file);

--- a/src/translation/frappe.translation.controller.ts
+++ b/src/translation/frappe.translation.controller.ts
@@ -42,6 +42,7 @@ export default class FrappeTranslationController extends TranslationController {
   public async loadTranslations(
     loadTranslationsParams?: string | LoadTranslationsParams
   ) {
+    await this.getCore().frappe.checkRenovationCoreInstalled();
     let args: LoadTranslationsParams = {};
     if (typeof loadTranslationsParams === "string") {
       args = {

--- a/src/translation/frappe.translation.controller.ts
+++ b/src/translation/frappe.translation.controller.ts
@@ -42,7 +42,7 @@ export default class FrappeTranslationController extends TranslationController {
   public async loadTranslations(
     loadTranslationsParams?: string | LoadTranslationsParams
   ) {
-    await this.getCore().frappe.checkRenovationCoreInstalled();
+    await this.getCore().frappe.checkAppInstalled(["loadTranslations"]);
     let args: LoadTranslationsParams = {};
     if (typeof loadTranslationsParams === "string") {
       args = {


### PR DESCRIPTION
This PR involves two changes:

- JWT is now disabled by default and can be enabled by calling `enableJwt()`.
- Errors are thrown if using a method that calls renovation_core endpoints