### PR TITLE
use and export single axios instance + export all models interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,10 @@ export { RenovationBackend } from "./config";
 export * from "./utils";
 export * from "./tests";
 export * from "./model/interfaces";
-export * from "./utils/request";
+export {
+  RenovationError,
+  SessionStatus,
+  RequestResponse,
+  isBrowser,
+  isNodeJS
+} from "./utils/request";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,6 @@
-export { Renovation } from "./renovation";
+export { Renovation, InitParams } from "./renovation";
 export { RenovationBackend } from "./config";
 export * from "./utils";
 export * from "./tests";
-export { GetListParams } from "./model/interfaces";
-export {
-  RenovationError,
-  SessionStatus,
-  RequestResponse,
-  isBrowser,
-  isNodeJS
-} from "./utils/request";
+export * from "./model/interfaces";
+export * from "./utils/request";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,6 @@ export {
   SessionStatus,
   RequestResponse,
   isBrowser,
-  isNodeJS
+  isNodeJS,
+  axiosInstance
 } from "./utils/request";

--- a/src/lib/frappe.ts
+++ b/src/lib/frappe.ts
@@ -1,8 +1,8 @@
-import axios from "axios";
 import RenovationController from "../renovation.controller";
 import { asyncSleep, renovationError, renovationWarn } from "../utils";
 import { ErrorDetail } from "../utils/error";
 import {
+  axiosInstance,
   getClientId,
   onBrowser,
   RequestResponse,
@@ -145,7 +145,7 @@ export default class Frappe extends RenovationController {
    */
   private async fetchId(): Promise<RequestResponse<any>> {
     try {
-      const response = await axios({
+      const response = await axiosInstance({
         // plain request, we dont want to send x-client-site here
         method: "POST",
         url: this.config.hostUrl,

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -148,6 +148,8 @@ export const SessionStatus: BehaviorSubject<SessionStatusInfo> = new BehaviorSub
   } as SessionStatusInfo
 );
 
+export const axiosInstance = axios.create();
+
 /**
  * Wrapper for underlying HTTP Client used
  * @param url The URL of the endpoint
@@ -221,7 +223,7 @@ export async function Request(
   let _response;
   let r: RequestResponse<any>;
   try {
-    const response = await axios({
+    const response = await axiosInstance({
       method: _method,
       withCredentials: true,
       url,


### PR DESCRIPTION
we use a single axios instance and export it so we can use functionalities like interceptors..