### PR TITLE
fix: Use Regex pattern for parsing version

### DIFF
--- a/src/lib/frappe.ts
+++ b/src/lib/frappe.ts
@@ -208,13 +208,18 @@ export default class Frappe extends RenovationController {
   }
 
   private static parseAppVersion(version: AppVersion): AppVersion {
-    const segments = version.version.split(".");
+    if (version.version && version.version != "") {
+      let _version = version.version.match(/\d+(\.\d+){2,}/);
+      if (_version && _version.length > 0) {
+        const segments = _version[0].split(".");
 
-    if (segments && segments.length === 3) {
-      version.major = parseInt(segments[0]);
-      version.minor = parseInt(segments[1]);
-      version.patch = parseInt(segments[2]);
-      return version;
+        if (segments && segments.length === 3) {
+          version.major = parseInt(segments[0]);
+          version.minor = parseInt(segments[1]);
+          version.patch = parseInt(segments[2]);
+          return version;
+        }
+      }
     }
     throw Error("Version empty or not in proper format");
   }


### PR DESCRIPTION
This fixes issues when the app version contains strings such as `13.0.0-beta.2`.