### PR TITLE
fix: ExportReport (v12+)

### DIFF
--- a/src/model/frappe.model.controller.ts
+++ b/src/model/frappe.model.controller.ts
@@ -752,7 +752,8 @@ export default class FrappeModelController extends ModelController {
           file_format_type: exportReportParams.fileFormatType,
           filters: JSON.stringify(exportReportParams.filters),
           visible_idx: JSON.stringify(exportReportParams.visibleIDX),
-          include_indentation: exportReportParams.includeIndentation
+          include_indentation: exportReportParams.includeIndentation,
+          custom_columns: JSON.stringify([])
         }
       },
       "blob"


### PR DESCRIPTION
Custom Columns were introduced in v12: https://github.com/frappe/frappe/blob/version-12/frappe/desk/query_report.py#L311
For now, I have fixed the api error. We probably should understand what it is and add it to core-ts param-interface
