### PR TITLE
FIx: load translations of a specific language

### DIFF
--- a/src/translation/frappe.translation.controller.ts
+++ b/src/translation/frappe.translation.controller.ts
@@ -59,7 +59,7 @@ export default class FrappeTranslationController extends TranslationController {
 
     const r = await Request(
       `${this.getHostUrl()}/api/method/renovation_core.utils.client.get_lang_dict`,
-      httpMethod.GET,
+      httpMethod.POST,
       FrappeRequestOptions.headers,
       {
         contentType: contentType["application/x-www-form-urlencoded"],


### PR DESCRIPTION
Now we can observe the form data in chrome devtools.
<img width="386" alt="image" src="https://user-images.githubusercontent.com/41537985/91391267-ac0d5400-e84a-11ea-8e14-603028819464.png">
