### PR TITLE
Fix translate type set on init & set some getters

### DIFF
--- a/src/lib/frappe.ts
+++ b/src/lib/frappe.ts
@@ -23,6 +23,10 @@ export default class Frappe extends RenovationController {
     return this._appVersions;
   }
 
+  public get versionsLoaded() {
+    return this._versionsLoaded;
+  }
+
   public get frappeVersion() {
     return this._appVersions["frappe"];
   }

--- a/src/renovation.ts
+++ b/src/renovation.ts
@@ -20,7 +20,6 @@ import PermissionController from "./perm/perm.controller";
 import FrappeStorageController from "./storage/frappe.storage.controller";
 import StorageController from "./storage/storage.controller";
 import FrappeTranslationController from "./translation/frappe.translation.controller";
-import TranslationController from "./translation/translation.controller";
 import FrappeUIController from "./ui/frappe.ui.controller";
 import UIController from "./ui/ui.controller";
 import {
@@ -98,7 +97,7 @@ export class Renovation {
   /**
    * The `TranslationController` instance
    */
-  public translate!: TranslationController;
+  public translate!: FrappeTranslationController;
   /**
    * The `SocketIOClient` instance
    */

--- a/src/translation/frappe.translation.controller.ts
+++ b/src/translation/frappe.translation.controller.ts
@@ -15,8 +15,13 @@ import TranslationController from "./translation.controller";
  * Class handling the translation of Frappe
  */
 export default class FrappeTranslationController extends TranslationController {
+  private _translationsLoaded: boolean = false;
+
+  get translationsLoaded() {
+    return this._translationsLoaded;
+  }
   public handleError(errorId: string, error: ErrorDetail): ErrorDetail {
-    let err = {} as ErrorDetail;
+    let err: ErrorDetail;
     switch (errorId) {
       case "loadtranslation":
       default:
@@ -68,6 +73,7 @@ export default class FrappeTranslationController extends TranslationController {
         }
       }
     );
+    this._translationsLoaded = true;
     if (r.success && r.data) {
       r.data = r.data.message;
       this.setMessagesDict({ dict: r.data, lang: args.lang });


### PR DESCRIPTION
2 issues solved by these getters :
1. init core function does not await loadAppVersions.
2. user logs in session observer automatically calls load translations.

In a testing environment these getters are useful.

1 fix:
1. type set on init() for translate is TranslationController instead of FrappeTranslationController.

