### PR TITLE
fix: RXJS imports causing runtime error in Angular project (ng-11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "nock": "^10.0.6",
     "nock-record": "^0.3.3",
     "qs": "^6.5.2",
-    "rxjs": "^6.3.2",
-    "rxjs-compat": "^6.3.2",
+    "rxjs": "^6.6.3",
+    "rxjs-compat": "^6.6.3",
     "socket.io-client": "^2.2.0",
     "zxcvbn": "^4.4.2"
   },

--- a/src/lib/message.bus.ts
+++ b/src/lib/message.bus.ts
@@ -1,4 +1,4 @@
-import { Subject } from "rxjs/Subject";
+import { Subject } from "rxjs";
 import { renovationWarn } from "../utils";
 import { MessageBusGetSubjectParams, MessageBusPostParams } from "./interfaces";
 

--- a/src/renovation.ts
+++ b/src/renovation.ts
@@ -1,4 +1,4 @@
-import { Subject } from "rxjs/Subject";
+import { Subject } from "rxjs";
 import AuthController from "./auth/auth.controller";
 import FrappeAuthController from "./auth/frappe.auth.controller";
 import { RenovationBackend, RenovationConfig } from "./config";

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import qs from "qs";
-import { BehaviorSubject } from "rxjs/BehaviorSubject";
+import { BehaviorSubject } from "rxjs";
 import { RenovationConfig } from "../config";
 import { ErrorDetail } from "./error";
 import { renovationError, renovationLog, renovationWarn } from "./index";


### PR DESCRIPTION
# Issue

An angular application built using `ng build --prod`, will show the following error in the console when accessed.

<img width="380" alt="image" src="https://user-images.githubusercontent.com/5578999/107850785-7838e180-6e1e-11eb-8841-ed64c66a3bb2.png">


# Solution

Remove explicit imports of rxjs package, so instead of importing from `"rxjs/BehaviorSubject"` we import from `"rxjs`.

